### PR TITLE
Backport small fixes from rdr 2 port

### DIFF
--- a/ImGTA/mem_watcher_mod.cpp
+++ b/ImGTA/mem_watcher_mod.cpp
@@ -121,7 +121,7 @@ void MemWatcherMod::ShowAddAddress(bool isGlobal)
 	{
 		if (ImGui::InputInt("Hex Index##AddAddress", &m_inputAddressIndex, 1, 100, ImGuiInputTextFlags_CharsHexadecimal))
 		{
-			ClipInt(m_inputAddressIndex, 0, 999999);
+			ClipInt(m_inputAddressIndex, 0, INT32_MAX);
 			m_indexRange = 1;
 			m_inputsUpdated = true;
 		}
@@ -130,7 +130,7 @@ void MemWatcherMod::ShowAddAddress(bool isGlobal)
 	{
 		if (ImGui::InputInt("Decimal Index##AddAddress", &m_inputAddressIndex, 1, 100))
 		{
-			ClipInt(m_inputAddressIndex, 0, 999999);
+			ClipInt(m_inputAddressIndex, 0, INT32_MAX);
 			m_indexRange = 1;
 			m_inputsUpdated = true;
 		}

--- a/ImGTA/script.cpp
+++ b/ImGTA/script.cpp
@@ -76,9 +76,7 @@ void DLLObject::Update()
 	ResetTextDrawCount();
 	if (m_isOpen)
 	{
-		if (m_floatingMenu)
-			PAD::ENABLE_ALL_CONTROL_ACTIONS(0);
-		else
+		if (!m_floatingMenu)
 			PAD::DISABLE_ALL_CONTROL_ACTIONS(0);
 	}
 

--- a/ImGTA/scripts_mod.cpp
+++ b/ImGTA/scripts_mod.cpp
@@ -295,10 +295,10 @@ bool ScriptsMod::Draw()
 			m_selected = &s;
 			ImGui::OpenPopup("ScriptPropertiesPopup");
 		}
+		ImGui::PopID();
 		ImGui::NextColumn();
 
 		ImGui::Text("%d (0x%x)", s.m_handle, s.m_handle); ImGui::NextColumn();
-		ImGui::PopID();
 	}
 	ImGui::Columns(1);
 	ImGui::Separator();

--- a/ImGTA/scripts_mod.cpp
+++ b/ImGTA/scripts_mod.cpp
@@ -289,13 +289,12 @@ bool ScriptsMod::Draw()
 
 	for (auto& s : m_scripts)
 	{
-		ImGui::PushID(s.m_handle); //prevent id conflicts (scripts with the same name)
-		if (ImGui::Selectable(s.m_scriptName.c_str(), false, ImGuiSelectableFlags_SpanAllColumns))
+		//##s.m_handle prevents id conflicts (scripts with the same name)
+		if (ImGui::Selectable((s.m_scriptName + "##" + std::to_string(s.m_handle)).c_str(), false, ImGuiSelectableFlags_SpanAllColumns))
 		{
 			m_selected = &s;
 			ImGui::OpenPopup("ScriptPropertiesPopup");
 		}
-		ImGui::PopID();
 		ImGui::NextColumn();
 
 		ImGui::Text("%d (0x%x)", s.m_handle, s.m_handle); ImGui::NextColumn();

--- a/ImGTA/scripts_mod.cpp
+++ b/ImGTA/scripts_mod.cpp
@@ -287,22 +287,21 @@ bool ScriptsMod::Draw()
 		ImGui::Separator();
 	}
 
-	if (m_scripts.size() > 0)
+	for (auto& s : m_scripts)
 	{
-		for (auto &s : m_scripts)
+		ImGui::PushID(s.m_handle); //prevent id conflicts (scripts with the same name)
+		if (ImGui::Selectable(s.m_scriptName.c_str(), false, ImGuiSelectableFlags_SpanAllColumns))
 		{
-			if (ImGui::Selectable(s.m_scriptName.c_str(), false, ImGuiSelectableFlags_SpanAllColumns))
-			{
-				m_selected = &s;
-				ImGui::OpenPopup("ScriptPropertiesPopup");
-			}
-			ImGui::NextColumn();
-
-			ImGui::Text("%d (0x%x)", s.m_handle, s.m_handle); ImGui::NextColumn();
+			m_selected = &s;
+			ImGui::OpenPopup("ScriptPropertiesPopup");
 		}
-		ImGui::Columns(1);
-		ImGui::Separator();
+		ImGui::NextColumn();
+
+		ImGui::Text("%d (0x%x)", s.m_handle, s.m_handle); ImGui::NextColumn();
+		ImGui::PopID();
 	}
+	ImGui::Columns(1);
+	ImGui::Separator();
 
 	ShowSelectedPopup();
 


### PR DESCRIPTION
1) Do not clip global addresses to 99999, clip to INT32_MAX instead (we can probably delete clipping here entirely, I don't think it serves any purpose).
2) Fix script name collision which prevents pinning or terminating scripts with the same name.
3) Remove ENABLE_ALL_CONTROL_ACTIONS when floating menu is disabled. It shouldn't be there, only creates confusion and doesn't serve any purpose. 